### PR TITLE
httpresponse - NotFoundWithMessage fix

### DIFF
--- a/httpresponse/with_error.go
+++ b/httpresponse/with_error.go
@@ -56,7 +56,12 @@ func RespondWithMethodNotAllowedError(w http.ResponseWriter) error {
 	return RespondWithMethodNotAllowedErrorWithMessage(w, "Method Not Allowed")
 }
 
+// RespondWithNotFoundErrorWithMessage ...
+func RespondWithNotFoundErrorWithMessage(w http.ResponseWriter, errMsg string) error {
+	return RespondWithError(w, errMsg, http.StatusNotFound)
+}
+
 // RespondWithNotFoundError ...
 func RespondWithNotFoundError(w http.ResponseWriter) error {
-	return RespondWithError(w, "Not Found", http.StatusNotFound)
+	return RespondWithNotFoundErrorWithMessage(w, "Not Found")
 }

--- a/httpresponse/without_error.go
+++ b/httpresponse/without_error.go
@@ -53,14 +53,14 @@ func RespondWithBadRequestErrorNoErr(w http.ResponseWriter, errMsg string) {
 	RespondWithErrorNoErr(w, errMsg, http.StatusBadRequest)
 }
 
-// RespondWithNotFoundErrorWithMessage ...
-func RespondWithNotFoundErrorWithMessage(w http.ResponseWriter, errMsg string) {
+// RespondWithNotFoundErrorWithMessageNoErr ...
+func RespondWithNotFoundErrorWithMessageNoErr(w http.ResponseWriter, errMsg string) {
 	RespondWithErrorNoErr(w, errMsg, http.StatusNotFound)
 }
 
 // RespondWithNotFoundErrorNoErr ...
 func RespondWithNotFoundErrorNoErr(w http.ResponseWriter) {
-	RespondWithNotFoundErrorWithMessage(w, "Not Found")
+	RespondWithNotFoundErrorWithMessageNoErr(w, "Not Found")
 }
 
 // RespondWithInternalServerError ...


### PR DESCRIPTION
The existing RespondWithNotFoundErrorWithMessage was a no err function,
so I renamed it accordingly: `RespondWithNotFoundErrorWithMessage` -> `RespondWithNotFoundErrorWithMessageNoErr`

The error version of this function was also missing, only `RespondWithNotFoundError` was defined,
so I redefined `RespondWithNotFoundErrorWithMessage` but this time at the right place in `with_error.go`
and now it returns an error.