### PR TITLE
[WEB-4001] making sure set operation happens in transaction

### DIFF
--- a/redis/redis.go
+++ b/redis/redis.go
@@ -77,14 +77,27 @@ func NewPool(urlStr string, maxIdle, maxActive int) *redis.Pool {
 func (c *Client) Set(key string, value interface{}, ttl int) error {
 	conn := c.pool.Get()
 
-	conn.Send("MULTI")
-	conn.Send("SET", key, value)
+	err := conn.Send("MULTI")
 
-	if ttl > 0 {
-		conn.Send("EXPIRE", key, ttl)
+	if err != nil {
+		return err
 	}
 
-	_, err := conn.Do("EXEC")
+	err = conn.Send("SET", key, value)
+
+	if err != nil {
+		return err
+	}
+
+	if ttl > 0 {
+		err = conn.Send("EXPIRE", key, ttl)
+
+		if err != nil {
+			return err
+		}
+	}
+
+	_, err = conn.Do("EXEC")
 
 	if err != nil {
 		return err


### PR DESCRIPTION
wrap `SET` redis operation in transaction in order to handle parallelism without race condition. Inspiration: https://redis.io/commands/incr#pattern-rate-limiter-1